### PR TITLE
Add interconnected TypeScript classes for A, B, C, and D

### DIFF
--- a/A/A.ts
+++ b/A/A.ts
@@ -1,0 +1,56 @@
+import type { B } from "../B/B";
+import type { C } from "../C/C";
+import type { D } from "../D/D";
+
+export class A {
+  private readonly interactions: string[] = [];
+
+  sendTest(to: B): void {
+    this.log("Sent test directive to B");
+    to.receiveTest(this);
+  }
+
+  sendMessage(to: B, message: string): void {
+    this.log(`Sent message to B: ${message}`);
+    to.receiveMessage(this, message);
+  }
+
+  sendAdvocate(to: B, advocate: string): void {
+    this.log(`Sent advocate '${advocate}' to B`);
+    to.receiveAdvocate(this, advocate);
+  }
+
+  requestAnalysis(from: C, topic: string): void {
+    this.log(`Requested analysis on ${topic} from C`);
+    from.provideAnalysis(this, topic);
+  }
+
+  assignTask(to: D, task: string): void {
+    this.log(`Assigned task '${task}' to D`);
+    to.acceptTask(this, task);
+  }
+
+  registerThank(from: B, note: string): void {
+    this.log(`Received thanks from B: ${note}`);
+  }
+
+  registerReply(from: B, message: string): void {
+    this.log(`Received reply from B: ${message}`);
+  }
+
+  recordReportFromC(from: C, report: string): void {
+    this.log(`Received report from C: ${report}`);
+  }
+
+  handleAlertFromD(from: D, alert: string): void {
+    this.log(`Received alert from D: ${alert}`);
+  }
+
+  getHistory(): readonly string[] {
+    return this.interactions;
+  }
+
+  private log(entry: string): void {
+    this.interactions.push(entry);
+  }
+}

--- a/B/B.ts
+++ b/B/B.ts
@@ -1,0 +1,59 @@
+import type { A } from "../A/A";
+import type { C } from "../C/C";
+import type { D } from "../D/D";
+
+export class B {
+  private readonly interactions: string[] = [];
+
+  receiveTest(from: A): void {
+    this.log("Received test directive from A");
+  }
+
+  receiveMessage(from: A, message: string): void {
+    this.log(`Received message from A: ${message}`);
+  }
+
+  receiveAdvocate(from: A, advocate: string): void {
+    this.log(`Received advocate '${advocate}' from A`);
+  }
+
+  sendThank(to: A, note: string): void {
+    this.log(`Sent thanks to A: ${note}`);
+    to.registerThank(this, note);
+  }
+
+  sendReply(to: A, message: string): void {
+    this.log(`Sent reply to A: ${message}`);
+    to.registerReply(this, message);
+  }
+
+  coordinateWithC(partner: C, subject: string): void {
+    this.log(`Coordinated with C on ${subject}`);
+    partner.acceptCoordination(this, subject);
+  }
+
+  receiveFeedback(from: C, summary: string): void {
+    this.log(`Received feedback from C: ${summary}`);
+  }
+
+  receiveIdeaExchange(from: C, topic: string): void {
+    this.log(`Exchanged ideas with C on ${topic}`);
+  }
+
+  shareStrategy(withPartner: D, plan: string): void {
+    this.log(`Shared strategy with D: ${plan}`);
+    withPartner.receiveStrategy(this, plan);
+  }
+
+  receiveStrategyResponse(from: D, response: string): void {
+    this.log(`Received strategy response from D: ${response}`);
+  }
+
+  getHistory(): readonly string[] {
+    return this.interactions;
+  }
+
+  private log(entry: string): void {
+    this.interactions.push(entry);
+  }
+}

--- a/C/C.ts
+++ b/C/C.ts
@@ -1,0 +1,49 @@
+import type { A } from "../A/A";
+import type { B } from "../B/B";
+import type { D } from "../D/D";
+
+export class C {
+  private readonly interactions: string[] = [];
+
+  provideAnalysis(to: A, topic: string): void {
+    const report = `Analysis on ${topic}`;
+    this.log(`Provided analysis to A: ${report}`);
+    to.recordReportFromC(this, report);
+  }
+
+  acceptCoordination(from: B, subject: string): void {
+    this.log(`Accepted coordination from B on ${subject}`);
+  }
+
+  sendFeedback(to: B, summary: string): void {
+    this.log(`Sent feedback to B: ${summary}`);
+    to.receiveFeedback(this, summary);
+  }
+
+  exchangeIdeasWithB(partner: B, topic: string): void {
+    this.log(`Initiated idea exchange with B on ${topic}`);
+    partner.receiveIdeaExchange(this, topic);
+  }
+
+  alignWithD(partner: D, priority: string): void {
+    this.log(`Aligned with D on priority: ${priority}`);
+    partner.confirmAlignment(this, priority);
+  }
+
+  receiveUpdateFromD(from: D, update: string): void {
+    this.log(`Received update from D: ${update}`);
+  }
+
+  reportToA(target: A, report: string): void {
+    this.log(`Reported to A: ${report}`);
+    target.recordReportFromC(this, report);
+  }
+
+  getHistory(): readonly string[] {
+    return this.interactions;
+  }
+
+  private log(entry: string): void {
+    this.interactions.push(entry);
+  }
+}

--- a/D/D.ts
+++ b/D/D.ts
@@ -1,0 +1,42 @@
+import type { A } from "../A/A";
+import type { B } from "../B/B";
+import type { C } from "../C/C";
+
+export class D {
+  private readonly interactions: string[] = [];
+
+  acceptTask(from: A, task: string): void {
+    this.log(`Accepted task from A: ${task}`);
+  }
+
+  receiveStrategy(from: B, plan: string): void {
+    this.log(`Received strategy from B: ${plan}`);
+  }
+
+  confirmAlignment(withPartner: C, priority: string): void {
+    this.log(`Confirmed alignment with C on ${priority}`);
+  }
+
+  shareUpdate(to: C, update: string): void {
+    this.log(`Shared update with C: ${update}`);
+    to.receiveUpdateFromD(this, update);
+  }
+
+  sendAlert(to: A, alert: string): void {
+    this.log(`Sent alert to A: ${alert}`);
+    to.handleAlertFromD(this, alert);
+  }
+
+  respondToStrategy(to: B, response: string): void {
+    this.log(`Responded to B's strategy: ${response}`);
+    to.receiveStrategyResponse(this, response);
+  }
+
+  getHistory(): readonly string[] {
+    return this.interactions;
+  }
+
+  private log(entry: string): void {
+    this.interactions.push(entry);
+  }
+}


### PR DESCRIPTION
## Summary
- add class A to initiate communications with the other components and capture their responses
- add class B with bidirectional workflows to and from A alongside collaborations with C and D
- add class C to exchange reports with A while coordinating with B and D
- add class D that supports assignments from A and synchronizes with B and C

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dd6fe7ea38832082cbf5cea47d74ba